### PR TITLE
Improve SEO and emphasize 'memory chess' keywords on homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,9 +8,22 @@ import VideoSection from '@/components/ui/VideoSection';
 import Footer from '@/components/ui/Footer';
 import { useState, useEffect } from 'react';
 import { formatNumber } from '@/lib/utils';
+import Script from 'next/script';
 
 export default function Home() {
   const [totalPlays, setTotalPlays] = useState<number | null>(null);
+
+  const websiteSchema = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "Memory Chess",
+    "url": "https://thememorychess.com",
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": "https://thememorychess.com/?s={search_term_string}",
+      "query-input": "required name=search_term_string"
+    }
+  };
 
   // Fetch total plays from Supabase on component mount
   useEffect(() => {
@@ -51,14 +64,24 @@ export default function Home() {
         <div className="flex justify-center mb-8">
           <PageHeader showSoundSettings={false} />
         </div>
-        
+        <Script id="website-schema" type="application/ld+json" strategy="afterInteractive">
+          {JSON.stringify(websiteSchema)}
+        </Script>
+
         <div className="flex flex-col items-center justify-center space-y-8 text-center mb-12">
+          <h1 className="text-3xl sm:text-4xl font-extrabold text-text-primary">
+            Memory Chess: Free Online Trainer for Chess Visualization &amp; Recall
+          </h1>
           <h2 className="text-xl font-bold text-peach-500">
             Total Games Played: {totalPlays !== null ? formatNumber(totalPlays) : '...'}
           </h2>
-          
+
           <p className="max-w-2xl text-lg text-text-secondary">
-            Train your chess memory and visualization skills through interactive exercises
+            Memory Chess strengthens board vision, spatial memory, and calculation speed through interactive memory chess board recall exercises.
+          </p>
+          <p className="max-w-2xl text-lg text-text-secondary">
+            Join players worldwide improving their memory chess visualization skills and track your results on the{' '}
+            <Link href="/leaderboard" className="underline hover:text-peach-500">leaderboard</Link>.
           </p>
 
           <div className="flex flex-col gap-4 sm:flex-row sm:gap-6">
@@ -89,18 +112,18 @@ export default function Home() {
           {/* Three cards grid */}
           <div className="mt-12 grid gap-8 sm:grid-cols-3 w-full max-w-4xl">
             <div className="rounded-xl border border-bg-light bg-bg-card p-6 shadow-md transition-all hover:shadow-lg">
-              <h2 className="mb-2 text-xl font-semibold text-text-primary">Visualization</h2>
-              <p className="text-text-secondary">Sharpen your mind&apos;s eye for chess, programming, and problem-solving.</p>
+              <h2 className="mb-2 text-xl font-semibold text-text-primary">Memory Chess Board Visualization</h2>
+              <p className="text-text-secondary">Sharpen your mind&apos;s eye for chess, programming, and problem-solving with memory chess board patterns.</p>
             </div>
 
             <div className="rounded-xl border border-bg-light bg-bg-card p-6 shadow-md transition-all hover:shadow-lg">
-              <h2 className="mb-2 text-xl font-semibold text-text-primary">Memory</h2>
-              <p className="text-text-secondary">Master grandmaster techniques to hold complex information effortlessly.</p>
+              <h2 className="mb-2 text-xl font-semibold text-text-primary">Spatial Memory Training</h2>
+              <p className="text-text-secondary">Master grandmaster techniques to remember complex memory chess positions effortlessly.</p>
             </div>
 
             <div className="rounded-xl border border-bg-light bg-bg-card p-6 shadow-md transition-all hover:shadow-lg">
-              <h2 className="mb-2 text-xl font-semibold text-text-primary">Progress</h2>
-              <p className="text-text-secondary">See measurable improvements with just 10-15 minutes of daily practice.</p>
+              <h2 className="mb-2 text-xl font-semibold text-text-primary">Progress Tracking</h2>
+              <p className="text-text-secondary">See measurable improvements with just 10-15 minutes of daily memory chess practice.</p>
             </div>
           </div>
           

--- a/src/components/ui/FaqSection.tsx
+++ b/src/components/ui/FaqSection.tsx
@@ -6,13 +6,89 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import Script from 'next/script';
 
 export default function FaqSection() {
+  const faqSchema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "What is mental visualization and why is it valuable?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Mental visualization is creating and manipulating images in your mind's eye. It accelerates thinking and improves decision making. Memory Chess exercises these skills by challenging you to recreate chessboard positions from memory."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do experts demonstrate visualization abilities?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Chess grandmasters track pieces mentally across simultaneous games. Memory Chess builds similar skills by starting with simple patterns and increasing difficulty to train expert-level board vision."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What short-term strategies can optimize my visualization for specific tasks?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Focus on key pieces first, practice visualizing 3D relationships, and recreate positions from memory before submitting answers in Memory Chess."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What long-term practices improve visualization abilities permanently?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Progress through harder Memory Chess levels, analyze mistakes, and challenge yourself to visualize accurately under tighter time constraints."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Is there a limit to how much one can visualize at once?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Memory Chess expands your capacity gradually. By chunking patterns rather than individual pieces, you learn to handle more complex positions."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How does visualization practice improve overall thinking?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Regular Memory Chess training makes your brain more efficient at processing complex information mentally, benefiting tasks from programming to design."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can anyone improve visualization skills, or is it innate?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Almost everyone can enhance visualization with structured practice. Memory Chess users report significant gains, showing the skill is learnable."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How much time should I dedicate to visualization practice?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Sessions of 10-15 minutes a day on Memory Chess can yield noticeable improvements within weeks."
+        }
+      }
+    ]
+  };
+
   return (
     <div className="w-full max-w-4xl mx-auto py-12 px-2 sm:px-4 md:py-16 mt-8 border-t border-bg-light">
       <h2 className="text-2xl sm:text-3xl font-bold text-center mb-8 sm:mb-10 text-text-primary">
-        Frequently Asked Questions About Visualizing Anything
+        Frequently Asked Questions About Memory Chess Visualization Training
       </h2>
+
+      <Script id="faq-schema" type="application/ld+json" strategy="afterInteractive">
+        {JSON.stringify(faqSchema)}
+      </Script>
 
       <Accordion type="single" collapsible className="w-full">
         <AccordionItem value="item-1" className="border-bg-light">
@@ -20,7 +96,7 @@ export default function FaqSection() {
             What is mental visualization and why is it valuable?
           </AccordionTrigger>
           <AccordionContent className="text-text-secondary text-sm sm:text-base px-2 pb-6">
-            Mental visualization is creating and manipulating images in your mind&apos;s eye. It accelerates thinking, enhances problem-solving, improves decision-making, and makes information more intuitive. MemoryChess provides targeted training by challenging you to remember board positions after viewing them briefly, then recreating them from memory—directly exercising the visualization muscles needed for advanced thinking across domains.
+            Mental visualization is creating and manipulating images in your mind&apos;s eye. It accelerates thinking, enhances problem-solving, improves decision-making, and makes information more intuitive. Memory Chess provides targeted training by challenging you to remember board positions after viewing them briefly, then recreating them from memory—directly exercising the visualization muscles needed for advanced thinking across domains.
           </AccordionContent>
         </AccordionItem>
 
@@ -29,7 +105,7 @@ export default function FaqSection() {
             How do experts demonstrate visualization abilities?
           </AccordionTrigger>
           <AccordionContent className="text-text-secondary text-sm sm:text-base px-2 pb-6">
-            Chess grandmasters track pieces mentally across multiple simultaneous games. Competitive programmers maintain complex mental models of problems without referencing original information. MemoryChess specifically builds this skill by starting with simple board patterns and progressively increasing difficulty, training your mind to hold and manipulate positions the way experts do naturally.
+            Chess grandmasters track pieces mentally across multiple simultaneous games. Competitive programmers maintain complex mental models of problems without referencing original information. Memory Chess specifically builds this skill by starting with simple board patterns and progressively increasing difficulty, training your mind to hold and manipulate positions the way experts do naturally.
           </AccordionContent>
         </AccordionItem>
 
@@ -39,9 +115,9 @@ export default function FaqSection() {
           </AccordionTrigger>
           <AccordionContent className="text-text-secondary text-sm sm:text-base px-2 pb-6">
             <ul className="list-disc pl-5 sm:pl-6 space-y-2 sm:space-y-3">
-              <li>Focus on important pieces first when using MemoryChess, ignoring less crucial elements</li>
-              <li>Practice visualizing the 3D relationships between pieces on MemoryChess&apos;s 2D board</li>
-              <li>Use the physical MemoryChess board initially, then close your eyes to recreate positions before submitting answers</li>
+              <li>Focus on important pieces first when using Memory Chess, ignoring less crucial elements</li>
+              <li>Practice visualizing the 3D relationships between pieces on Memory Chess&apos;s 2D board</li>
+              <li>Use the physical Memory Chess board initially, then close your eyes to recreate positions before submitting answers</li>
             </ul>
           </AccordionContent>
         </AccordionItem>
@@ -52,9 +128,9 @@ export default function FaqSection() {
           </AccordionTrigger>
           <AccordionContent className="text-text-secondary text-sm sm:text-base px-2 pb-6">
             <ul className="list-disc pl-5 sm:pl-6 space-y-2 sm:space-y-3">
-              <li>Start with easier MemoryChess levels, progressively reducing viewing time as your skills improve</li>
-              <li>After each MemoryChess exercise, analyze where your memory failed and develop strategies to strengthen those areas</li>
-              <li>Set personal speed records on MemoryChess, challenging yourself to visualize positions accurately under tighter time constraints</li>
+              <li>Start with easier Memory Chess levels, progressively reducing viewing time as your skills improve</li>
+              <li>After each Memory Chess exercise, analyze where your memory failed and develop strategies to strengthen those areas</li>
+              <li>Set personal speed records on Memory Chess, challenging yourself to visualize positions accurately under tighter time constraints</li>
             </ul>
           </AccordionContent>
         </AccordionItem>
@@ -64,7 +140,7 @@ export default function FaqSection() {
             Is there a limit to how much one can visualize at once?
           </AccordionTrigger>
           <AccordionContent className="text-text-secondary text-sm sm:text-base px-2 pb-6">
-            Yes, but MemoryChess helps expand these limits systematically. The platform&apos;s progressive difficulty increases the number of pieces and complexity of positions gradually, training your mind to handle increasingly complex visual information. Focus on chunking—seeing patterns rather than individual pieces—to overcome natural limitations.
+            Yes, but Memory Chess helps expand these limits systematically. The platform&apos;s progressive difficulty increases the number of pieces and complexity of positions gradually, training your mind to handle increasingly complex visual information. Focus on chunking—seeing patterns rather than individual pieces—to overcome natural limitations.
           </AccordionContent>
         </AccordionItem>
 
@@ -73,7 +149,7 @@ export default function FaqSection() {
             How does visualization practice improve overall thinking?
           </AccordionTrigger>
           <AccordionContent className="text-text-secondary text-sm sm:text-base px-2 pb-6">
-            Regular MemoryChess training enhances your ability to process complex information mentally. As you improve at holding chess positions in mind, you&apos;ll notice benefits in other areas requiring visualization—from programming to design. Your brain becomes more efficient at creating mental workspaces for reasoning through problems without external aids.
+            Regular Memory Chess training enhances your ability to process complex information mentally. As you improve at holding chess positions in mind, you&apos;ll notice benefits in other areas requiring visualization—from programming to design. Your brain becomes more efficient at creating mental workspaces for reasoning through problems without external aids.
           </AccordionContent>
         </AccordionItem>
 
@@ -82,7 +158,7 @@ export default function FaqSection() {
             Can anyone improve visualization skills, or is it innate?
           </AccordionTrigger>
           <AccordionContent className="text-text-secondary text-sm sm:text-base px-2 pb-6">
-            Almost everyone can significantly improve their visualization through structured practice. MemoryChess provides this structure with measurable progress metrics, allowing anyone (except those with aphantasia) to enhance their visualization skills regardless of starting ability. Many MemoryChess users report dramatic improvements from consistent practice, confirming this skill is learnable, not just innate.
+            Almost everyone can significantly improve their visualization through structured practice. Memory Chess provides this structure with measurable progress metrics, allowing anyone (except those with aphantasia) to enhance their visualization skills regardless of starting ability. Many Memory Chess users report dramatic improvements from consistent practice, confirming this skill is learnable, not just innate.
           </AccordionContent>
         </AccordionItem>
 
@@ -91,7 +167,7 @@ export default function FaqSection() {
             How much time should I dedicate to visualization practice?
           </AccordionTrigger>
           <AccordionContent className="text-text-secondary text-sm sm:text-base px-2 pb-6">
-            MemoryChess sessions as brief as 10-15 minutes daily can yield significant improvements. The platform&apos;s game-like format makes consistent practice enjoyable rather than tedious. Users typically see progress within weeks of regular engagement, making it an efficient use of limited practice time compared to unstructured visualization exercises.
+            Memory Chess sessions as brief as 10-15 minutes daily can yield significant improvements. The platform&apos;s game-like format makes consistent practice enjoyable rather than tedious. Users typically see progress within weeks of regular engagement, making it an efficient use of limited practice time compared to unstructured visualization exercises.
           </AccordionContent>
         </AccordionItem>
       </Accordion>

--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -58,7 +58,7 @@ export default function Footer() {
         </div>
         
         <div className="pt-6 text-center text-text-secondary text-sm">
-          <p>&copy; {currentYear} TheMemoryChess. All rights reserved.</p>
+          <p>&copy; {currentYear} Memory Chess. All rights reserved.</p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- Increase memory chess keyword density in homepage hero and feature descriptions
- Replace `MemoryChess` branding with spaced `Memory Chess` and update FAQ heading/content
- Update footer copy to include "Memory Chess" phrasing for consistent SEO

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: supabaseUrl is required; Failed to collect page data for /api/game-stats)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8bf22a448324a9d10224ebdcc40e